### PR TITLE
Add Nixos Flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ re.sh
 /scripts/local/
 /.env
 node_modules/
+
+# Nix
+/result
+/flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -16,25 +16,49 @@
           pkgs = import nixpkgs {
             inherit system;
           };
-
           craneLib = crane.mkLib pkgs;
 
-          kairpodsd = craneLib.buildPackage {
-            src = craneLib.cleanCargoSource ./service;
-            nativeBuildInputs = with pkgs; [
-              pkg-config
-            ];
-            buildInputs = with pkgs; [
-              dbus
-              bluez
-            ];
-          };
+          # check that the service unit file has not changed
+          serviceUnitHashValid =
+            let
+              serviceUnitPath = ./service/systemd/user/kairpodsd.service;
+              expectedServiceUnitHash = "sha256-aWc/ii+K8S6wElIq1tm0Rr3aUzXWGsYUSFy9idGTXQY=";
+              actualServiceUnitHash = builtins.convertHash rec {
+                hashAlgo = "sha256";
+                toHashFormat = "sri";
+                hash = builtins.hashFile hashAlgo serviceUnitPath;
+              };
+            in
+            if actualServiceUnitHash != expectedServiceUnitHash then
+              throw ''
+                kAirPods flake error: service/systemd/user/kairpodsd.service changed.
 
-          # --- Plasmoid packaging ---
-          # Plasma searches $XDG_DATA_DIRS/share/plasma/plasmoids/<id>.
-          # By shipping the directory in the Nix store and installing it via home.packages,
-          # Plasma will see it as long as XDG_DATA_DIRS includes the profile share path
-          # (Home Manager/NixOS do this).
+                Expected hash: "${expectedServiceUnitHash}"
+                Actual hash: "${actualServiceUnitHash}"
+
+                Update the Home Manager `systemd.user.services.kairpodsd` definition to match,
+                then update `expectedServiceUnitHash`.
+              ''
+            else
+              true;
+
+          # if the service unit file is valid, build the service package
+          kairpodsd =
+            if serviceUnitHashValid then
+              craneLib.buildPackage
+                {
+                  src = craneLib.cleanCargoSource ./service;
+                  nativeBuildInputs = with pkgs; [
+                    pkg-config
+                  ];
+                  buildInputs = with pkgs; [
+                    dbus
+                    bluez
+                  ];
+                }
+            else null;
+
+          # Plasma searches $XDG_DATA_DIRS/share/plasma/plasmoids/<id> for plasmoids
           kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation rec {
             pname = "org.kairpods.plasma";
             version = "0.1.0";

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
             installPhase = ''
               runHook preInstall
               mkdir -p "$out/share/plasma/plasmoids"
-              cp -R ./plasmoid "$out/share/plasma/plasmoids/${plasmoidId}"
+              ln -s "$src" "$out/share/plasma/plasmoids/${pname}"
               runHook postInstall
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-
-    # Rust builder with good Cargo.lock handling
     crane.url = "github:ipetkov/crane";
-
-    # Optional, but convenient for module wiring
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -17,85 +13,70 @@
     let
       # Shared module defaults
       serviceName = "kairpodsd";
-      plasmoidId  = "org.kairpods.plasma";
+      plasmoidId = "org.kairpods.plasma";
     in
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-
-        craneLib = crane.mkLib pkgs;
-
-        # --- Rust service build ---
-        # Build dependencies expected by your install script: dbus + bluez + pkg-config.
-        # Add openssl only if your crate uses it; remove if not needed.
-        commonBuildInputs = with pkgs; [
-          dbus
-          bluez
-        ];
-
-        commonNativeBuildInputs = with pkgs; [
-          pkg-config
-        ];
-
-        src = pkgs.lib.cleanSourceWith {
-          src = ./service;
-          filter = path: type:
-            # Keep everything except obvious junk
-            let base = builtins.baseNameOf path; in
-            !(base == "target" || base == ".git" || base == "result");
-        };
-
-        kairpodsd = craneLib.buildPackage {
-          pname = serviceName;
-          version = "0.1.0";
-          inherit src;
-
-          # If your crate uses a workspace, you can instead set:
-          # cargoToml = ./service/Cargo.toml; cargoLock = ./Cargo.lock;
-
-          nativeBuildInputs = commonNativeBuildInputs;
-          buildInputs = commonBuildInputs;
-
-          # If you need extra env for linking, add here.
-          # For example:
-          # PKG_CONFIG_PATH = "${pkgs.dbus.dev}/lib/pkgconfig:${pkgs.bluez.dev}/lib/pkgconfig";
-        };
-
-        # --- Plasmoid packaging ---
-        # Plasma searches $XDG_DATA_DIRS/share/plasma/plasmoids/<id>.
-        # By shipping the directory in the Nix store and installing it via home.packages,
-        # Plasma will see it as long as XDG_DATA_DIRS includes the profile share path
-        # (Home Manager/NixOS do this).
-        kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation {
-          pname = plasmoidId;
-          version = "0.1.0";
-          src = ./.;
-
-          dontBuild = true;
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p "$out/share/plasma/plasmoids"
-            cp -R ./plasmoid "$out/share/plasma/plasmoids/${plasmoidId}"
-            runHook postInstall
-          '';
-
-          meta = with pkgs.lib; {
-            description = "kAirPods Plasma 6 widget (plasmoid) for AirPods battery display";
-            platforms = platforms.linux;
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
           };
-        };
 
-      in {
-        packages = {
-          default = kairpodsd;
-          kairpodsd = kairpodsd;
-          plasmoid = kairpods-plasmoid;
-        };
-      }
-    )
+          craneLib = crane.mkLib pkgs;
+
+          src = pkgs.lib.cleanSourceWith {
+            src = ./service;
+          };
+
+          kairpodsd = craneLib.buildPackage {
+            pname = serviceName;
+            version = "0.1.0";
+            src = pkgs.lib.cleanSourceWith {
+              src = ./service;
+            };
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+            buildInputs = with pkgs; [
+              dbus
+              bluez
+            ];
+          };
+
+          # --- Plasmoid packaging ---
+          # Plasma searches $XDG_DATA_DIRS/share/plasma/plasmoids/<id>.
+          # By shipping the directory in the Nix store and installing it via home.packages,
+          # Plasma will see it as long as XDG_DATA_DIRS includes the profile share path
+          # (Home Manager/NixOS do this).
+          kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation {
+            pname = plasmoidId;
+            version = "0.1.0";
+            src = ./.;
+
+            dontBuild = true;
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p "$out/share/plasma/plasmoids"
+              cp -R ./plasmoid "$out/share/plasma/plasmoids/${plasmoidId}"
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "kAirPods Plasma 6 widget (plasmoid) for AirPods battery display";
+              platforms = platforms.linux;
+            };
+          };
+
+        in
+        {
+          packages = {
+            default = kairpodsd;
+            kairpodsd = kairpodsd;
+            plasmoid = kairpods-plasmoid;
+          };
+        }
+      )
     //
     {
       # ---------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,186 @@
+{
+  description = "kAirPods: kairpodsd user service + Plasma 6 plasmoid (org.kairpods.plasma)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # Rust builder with good Cargo.lock handling
+    crane.url = "github:ipetkov/crane";
+
+    # Optional, but convenient for module wiring
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane, home-manager, ... }:
+    let
+      # Shared module defaults
+      serviceName = "kairpodsd";
+      plasmoidId  = "org.kairpods.plasma";
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        craneLib = crane.mkLib pkgs;
+
+        # --- Rust service build ---
+        # Build dependencies expected by your install script: dbus + bluez + pkg-config.
+        # Add openssl only if your crate uses it; remove if not needed.
+        commonBuildInputs = with pkgs; [
+          dbus
+          bluez
+        ];
+
+        commonNativeBuildInputs = with pkgs; [
+          pkg-config
+        ];
+
+        src = pkgs.lib.cleanSourceWith {
+          src = ./service;
+          filter = path: type:
+            # Keep everything except obvious junk
+            let base = builtins.baseNameOf path; in
+            !(base == "target" || base == ".git" || base == "result");
+        };
+
+        kairpodsd = craneLib.buildPackage {
+          pname = serviceName;
+          version = "0.1.0";
+          inherit src;
+
+          # If your crate uses a workspace, you can instead set:
+          # cargoToml = ./service/Cargo.toml; cargoLock = ./Cargo.lock;
+
+          nativeBuildInputs = commonNativeBuildInputs;
+          buildInputs = commonBuildInputs;
+
+          # If you need extra env for linking, add here.
+          # For example:
+          # PKG_CONFIG_PATH = "${pkgs.dbus.dev}/lib/pkgconfig:${pkgs.bluez.dev}/lib/pkgconfig";
+        };
+
+        # --- Plasmoid packaging ---
+        # Plasma searches $XDG_DATA_DIRS/share/plasma/plasmoids/<id>.
+        # By shipping the directory in the Nix store and installing it via home.packages,
+        # Plasma will see it as long as XDG_DATA_DIRS includes the profile share path
+        # (Home Manager/NixOS do this).
+        kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation {
+          pname = plasmoidId;
+          version = "0.1.0";
+          src = ./.;
+
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/share/plasma/plasmoids"
+            cp -R ./plasmoid "$out/share/plasma/plasmoids/${plasmoidId}"
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "kAirPods Plasma 6 widget (plasmoid) for AirPods battery display";
+            platforms = platforms.linux;
+          };
+        };
+
+      in {
+        packages = {
+          default = kairpodsd;
+          kairpodsd = kairpodsd;
+          plasmoid = kairpods-plasmoid;
+        };
+      }
+    )
+    //
+    {
+      # ---------------------------
+      # Home Manager module
+      # ---------------------------
+      homeManagerModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.services.kairpods;
+        in
+        {
+          options.services.kairpods = {
+            enable = lib.mkEnableOption "kAirPods (kairpodsd user service + Plasma plasmoid)";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.kairpodsd;
+              defaultText = "kAirPods kairpodsd package from this flake";
+              description = "Package providing the kairpodsd binary.";
+            };
+            plasmoidPackage = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.plasmoid;
+              defaultText = "kAirPods plasmoid package from this flake";
+              description = "Package providing the org.kairpods.plasma plasmoid.";
+            };
+            autoStart = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether to enable and start the systemd --user service.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [
+              cfg.package
+              cfg.plasmoidPackage
+            ];
+
+            systemd.user.services.kairpodsd = lib.mkIf cfg.autoStart {
+              Unit = {
+                Description = "kAirPods daemon (AirPods battery + integration)";
+                After = [ "graphical-session.target" "dbus.service" ];
+                PartOf = [ "graphical-session.target" ];
+              };
+              Service = {
+                ExecStart = "${cfg.package}/bin/kairpodsd";
+                Restart = "on-failure";
+                RestartSec = 1;
+              };
+              Install = {
+                WantedBy = [ "default.target" ];
+              };
+            };
+          };
+        };
+
+      # ---------------------------
+      # NixOS module
+      # ---------------------------
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.services.kairpods;
+        in
+        {
+          options.services.kairpods = {
+            enable = lib.mkEnableOption "kAirPods: enable Bluetooth Experimental and provide guidance for user setup";
+            enableBluezExperimental = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Enable BlueZ Experimental = true (required for AirPods battery info on many setups).";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            # Your script edits /etc/bluetooth/main.conf. On NixOS, do it declaratively:
+            services.bluetooth.enable = true;
+            services.bluetooth.settings = lib.mkIf cfg.enableBluezExperimental {
+              General = {
+                Experimental = true;
+              };
+            };
+
+            # Note: user must be in bluetooth group if your daemon relies on it.
+            # NixOS typically has the bluetooth group; add your user like:
+            # users.users.<name>.extraGroups = [ "bluetooth" ];
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,6 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, crane, home-manager, ... }:
-    let
-      # Shared module defaults
-      serviceName = "kairpodsd";
-      plasmoidId = "org.kairpods.plasma";
-    in
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -24,16 +19,8 @@
 
           craneLib = crane.mkLib pkgs;
 
-          src = pkgs.lib.cleanSourceWith {
-            src = ./service;
-          };
-
           kairpodsd = craneLib.buildPackage {
-            pname = serviceName;
-            version = "0.1.0";
-            src = pkgs.lib.cleanSourceWith {
-              src = ./service;
-            };
+            src = craneLib.cleanCargoSource ./service;
             nativeBuildInputs = with pkgs; [
               pkg-config
             ];
@@ -48,10 +35,10 @@
           # By shipping the directory in the Nix store and installing it via home.packages,
           # Plasma will see it as long as XDG_DATA_DIRS includes the profile share path
           # (Home Manager/NixOS do this).
-          kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation {
-            pname = plasmoidId;
+          kairpods-plasmoid = pkgs.stdenvNoCC.mkDerivation rec {
+            pname = "org.kairpods.plasma";
             version = "0.1.0";
-            src = ./.;
+            src = ./plasmoid;
 
             dontBuild = true;
 

--- a/flake.nix
+++ b/flake.nix
@@ -135,14 +135,17 @@
 
             systemd.user.services.kairpodsd = lib.mkIf cfg.autoStart {
               Unit = {
-                Description = "kAirPods daemon (AirPods battery + integration)";
-                After = [ "graphical-session.target" "dbus.service" ];
-                PartOf = [ "graphical-session.target" ];
+                Description = "kAirPods D-Bus Service";
+                After = [ "graphical-session.target" ];
               };
               Service = {
+                Type = "dbus";
+                BusName = "org.kairpods";
                 ExecStart = "${cfg.package}/bin/kairpodsd";
                 Restart = "on-failure";
-                RestartSec = 1;
+                RestartSec = "5";
+                PrivateTmp = "yes";
+                NoNewPrivileges = "yes";
               };
               Install = {
                 WantedBy = [ "default.target" ];

--- a/flake.nix
+++ b/flake.nix
@@ -91,13 +91,13 @@
             enable = lib.mkEnableOption "kAirPods (kairpodsd user service + Plasma plasmoid)";
             package = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.system}.kairpodsd;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.kairpodsd;
               defaultText = "kAirPods kairpodsd package from this flake";
               description = "Package providing the kairpodsd binary.";
             };
             plasmoidPackage = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.system}.plasmoid;
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.plasmoid;
               defaultText = "kAirPods plasmoid package from this flake";
               description = "Package providing the org.kairpods.plasma plasmoid.";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
       # ---------------------------
       # Home Manager module
       # ---------------------------
-      homeManagerModules.default = { config, lib, pkgs, ... }:
+      homeModules.default = { config, lib, pkgs, ... }:
         let
           cfg = config.services.kairpods;
         in

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,6 @@
         in
         {
           packages = {
-            default = kairpodsd;
             kairpodsd = kairpodsd;
             plasmoid = kairpods-plasmoid;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -133,37 +133,5 @@
             };
           };
         };
-
-      # ---------------------------
-      # NixOS module
-      # ---------------------------
-      nixosModules.default = { config, lib, pkgs, ... }:
-        let
-          cfg = config.services.kairpods;
-        in
-        {
-          options.services.kairpods = {
-            enable = lib.mkEnableOption "kAirPods: enable Bluetooth Experimental and provide guidance for user setup";
-            enableBluezExperimental = lib.mkOption {
-              type = lib.types.bool;
-              default = true;
-              description = "Enable BlueZ Experimental = true (required for AirPods battery info on many setups).";
-            };
-          };
-
-          config = lib.mkIf cfg.enable {
-            # Your script edits /etc/bluetooth/main.conf. On NixOS, do it declaratively:
-            services.bluetooth.enable = true;
-            services.bluetooth.settings = lib.mkIf cfg.enableBluezExperimental {
-              General = {
-                Experimental = true;
-              };
-            };
-
-            # Note: user must be in bluetooth group if your daemon relies on it.
-            # NixOS typically has the bluetooth group; add your user like:
-            # users.users.<name>.extraGroups = [ "bluetooth" ];
-          };
-        };
     };
 }


### PR DESCRIPTION
I added a `flake.nix` that users can use to install the plasmoid on a nixos system that is using home-manager.  I am not sure if/how you want to add the info to the readme or install document.

I tested the flake on my system and it correctly builds and installs the service, and places the plasmoid in the correct location to be detected by plasma.

Considerations:
- The flake will use the version of rustc provided by nixpkgs, not the one specified in `rust-toolchain.toml`.  This seems fine since `rust-toolchain.toml` currently just says to use stable.
- The systemd service definition is hard coded in the flake. If `service/systemd/user/kairpodsd.service` is ever changed, the flake will detect it and throw an error to remind the contributer to update the corresponding defn in the flake.

The following is an example that shows how you would use the flake

```nix
inputs.kairpods.url = "github:can1357/kAirPods";

outputs = { self, nixpkgs, home-manager, kairpods, ... }: {
  homeConfigurations."user" = home-manager.lib.homeManagerConfiguration {
    pkgs = import nixpkgs { system = "x86_64-linux"; };
    modules = [
      kairpods.homeModules.default
      {
        services.kairpods.enable = true;
      }
    ];
  };
};
```